### PR TITLE
Fix data synchronization logic and test suite (#35)

### DIFF
--- a/inspect_container.py
+++ b/inspect_container.py
@@ -1,0 +1,24 @@
+import testcontainers
+import pkgutil
+import inspect
+
+def find_class(module_name, class_name):
+    """Recursively search for a class in a module and its submodules."""
+    try:
+        module = __import__(module_name, fromlist=[''])
+        for name, obj in inspect.getmembers(module):
+            if inspect.isclass(obj) and obj.__name__ == class_name:
+                print(f"Found class '{class_name}' in module '{module.__name__}'")
+                return
+            if inspect.ismodule(obj) and obj.__name__.startswith(module_name):
+                find_class(obj.__name__, class_name)
+    except ImportError:
+        pass
+
+# Start searching from the top-level 'testcontainers' package
+find_class("testcontainers", "LogMessageWaitStrategy")
+
+# Alternative: just print all submodules to find the 'wait' module
+import testcontainers.core
+for loader, module_name, is_pkg in pkgutil.walk_packages(testcontainers.core.__path__, testcontainers.core.__name__ + '.'):
+    print(module_name)

--- a/src/py_neo_umls_syncer/cli.py
+++ b/src/py_neo_umls_syncer/cli.py
@@ -57,6 +57,8 @@ def full_import(
         raise typer.Exit(code=1)
 
 
+from neo4j import GraphDatabase, Driver
+
 @app.command(name="init-meta", help="Initialize metadata after a successful bulk import.")
 def init_meta(
     version: str = typer.Option(
@@ -72,8 +74,10 @@ def init_meta(
     2. Creates the :UMLS_Meta node to lock in the current version.
     """
     console.print(Panel(f"[bold cyan]Initializing metadata for version: {version}[/bold cyan]", border_style="cyan"))
-    loader = Neo4jLoader()
+    driver = None
     try:
+        driver = GraphDatabase.driver(settings.neo4j_uri, auth=(settings.neo4j_user, settings.neo4j_password))
+        loader = Neo4jLoader(driver=driver)
         loader.update_meta_node_after_bulk(version)
         console.print(Panel(
             f"[bold green]Successfully initialized metadata for version {version}. The database is now ready for incremental syncs.[/bold green]",
@@ -84,7 +88,8 @@ def init_meta(
         console.print(Panel(f"[bold red]Failed to initialize metadata: {e}", title="[bold red]Error[/bold red]"))
         raise typer.Exit(code=1)
     finally:
-        loader.close()
+        if driver:
+            driver.close()
 
 @app.command(name="incremental-sync", help="Synchronize an existing DB with a new UMLS version.")
 def incremental_sync(
@@ -105,19 +110,32 @@ def incremental_sync(
     6. Updates the graph version.
     """
     console.print(Panel(f"[bold cyan]Starting Incremental Sync to Version: {version}[/bold cyan]", border_style="cyan"))
-
+    driver = None
     try:
         # Step 1: Download UMLS data
         meta_dir = download_umls_if_needed(version)
 
         # Step 2: Orchestrate the incremental sync
-        loader = Neo4jLoader()
+        driver = GraphDatabase.driver(settings.neo4j_uri, auth=(settings.neo4j_user, settings.neo4j_password))
+
+        # Pre-flight check: ensure the database has been initialized
+        with driver.session(database=settings.neo4j_database) as session:
+            meta_node = session.run("MATCH (m:UMLS_Meta) RETURN m").single()
+            if not meta_node:
+                console.print("[bold red]Error: UMLS_Meta node not found.[/bold red]")
+                console.print("Please run `full-import` and `init-meta` first.")
+                raise typer.Exit(code=1)
+
+        loader = Neo4jLoader(driver=driver)
         loader.run_incremental_sync(meta_dir, version)
 
     except Exception as e:
         console.print_exception()
         console.print(Panel(f"[bold red]An error occurred during the incremental sync process: {e}", title="[bold red]Error[/bold red]"))
         raise typer.Exit(code=1)
+    finally:
+        if driver:
+            driver.close()
 
 if __name__ == "__main__":
     app()

--- a/src/py_neo_umls_syncer/delta_strategy.py
+++ b/src/py_neo_umls_syncer/delta_strategy.py
@@ -68,120 +68,136 @@ class DeltaStrategy:
         # MERGEDCUI.RRF contains CUI_OLD|CUI_NEW
         merges = [row for row in csv.reader(merged_cui_file.open('r'), delimiter='|')]
 
-        # This query manually migrates relationships to ensure provenance is correctly merged,
-        # fulfilling the specific FRD requirement that `apoc.refactor.mergeNodes` cannot.
-        query = """
-        CALL apoc.periodic.iterate(
-          'UNWIND $merges AS merge_op
-           MATCH (old:Concept {cui: merge_op[0]}), (new:Concept {cui: merge_op[1]})
-           RETURN old, new',
-          '
-            // Migrate outgoing relationships
-            CALL {
-                WITH old, new
-                MATCH (old)-[r]->(target:Concept) WHERE target <> new
-                CALL apoc.merge.relationship(new, type(r), {source_rela: r.source_rela}, {}, target) YIELD rel AS new_rel
-                SET new_rel.asserted_by_sabs = apoc.coll.union(coalesce(new_rel.asserted_by_sabs, []), r.asserted_by_sabs),
-                    new_rel.last_seen_version = $version
-                RETURN count(*) AS out_rels
-            }
-            // Migrate incoming relationships
-            CALL {
-                WITH old, new
-                MATCH (source:Concept)-[r]->(old) WHERE source <> new
-                CALL apoc.merge.relationship(source, type(r), {source_rela: r.source_rela}, {}, new) YIELD rel AS new_rel
-                SET new_rel.asserted_by_sabs = apoc.coll.union(coalesce(new_rel.asserted_by_sabs, []), r.asserted_by_sabs),
-                    new_rel.last_seen_version = $version
-                RETURN count(*) AS in_rels
-            }
-            // Migrate codes
-            CALL {
-                WITH old, new
-                MATCH (old)-[r:HAS_CODE]->(c:Code)
-                MERGE (new)-[new_r:HAS_CODE]->(c)
-                SET new_r.last_seen_version = $version
-                RETURN count(*) AS code_rels
-            }
-            // Finally, delete the old, now-isolated concept
-            DETACH DELETE old
-          ',
-          {batchSize: $batchSize, parallel: false, params: {merges: $merges, version: $version}}
-        )
-        """
-        self._run_query(query, params={"merges": merges, "version": self.new_version, "batchSize": settings.apoc_batch_size})
-        console.log(f"Submitted merge task for {len(merges)} CUI pairs.")
+        # This process is broken down into sequential queries to avoid transactional
+        # complexities and ensure each step is handled atomically.
+        for old_cui, new_cui in merges:
+            # Check if the target node exists before attempting a merge
+            with self.driver.session(database=settings.neo4j_database) as session:
+                result = session.run("MATCH (c:Concept {cui: $cui}) RETURN c", cui=new_cui)
+                if not result.single():
+                    console.log(f"[bold yellow]Skipping merge for {old_cui} -> {new_cui}: Target CUI not found.[/bold yellow]")
+                    continue
+
+            params = {"old_cui": old_cui, "new_cui": new_cui, "version": self.new_version}
+
+            # Step 1: Migrate outgoing relationships
+            outgoing_rels_query = """
+            MATCH (old:Concept {cui: $old_cui}), (new:Concept {cui: $new_cui})
+            MATCH (old)-[r]->(target)
+            WHERE elementId(target) <> elementId(new) AND type(r) <> 'HAS_CODE'
+            WITH new, r, target
+            CALL apoc.merge.relationship(new, type(r), {source_rela: r.source_rela}, {}, target) YIELD rel
+            SET rel.asserted_by_sabs = apoc.coll.union(coalesce(rel.asserted_by_sabs, []), r.asserted_by_sabs),
+                rel.last_seen_version = $version
+            """
+            self._run_query(outgoing_rels_query, params)
+
+            # Step 2: Migrate incoming relationships
+            incoming_rels_query = """
+            MATCH (old:Concept {cui: $old_cui}), (new:Concept {cui: $new_cui})
+            MATCH (source)-[r]->(old)
+            WHERE elementId(source) <> elementId(new) AND type(r) <> 'HAS_CODE'
+            WITH source, new, r
+            CALL apoc.merge.relationship(source, type(r), {source_rela: r.source_rela}, {}, new) YIELD rel
+            SET rel.asserted_by_sabs = apoc.coll.union(coalesce(rel.asserted_by_sabs, []), r.asserted_by_sabs),
+                rel.last_seen_version = $version
+            """
+            self._run_query(incoming_rels_query, params)
+
+            # Step 3: Migrate codes
+            codes_query = """
+            MATCH (old:Concept {cui: $old_cui}), (new:Concept {cui: $new_cui})
+            MATCH (old)-[r:HAS_CODE]->(c:Code)
+            MERGE (new)-[new_r:HAS_CODE]->(c)
+            SET new_r.last_seen_version = $version
+            """
+            self._run_query(codes_query, params)
+
+            # Step 4: Delete the old concept
+            delete_query = "MATCH (c:Concept {cui: $old_cui}) DETACH DELETE c"
+            self._run_query(delete_query, params)
+
+        console.log(f"Processed {len(merges)} CUI merge operations.")
+
+    def _read_csv_to_list(self, filename: str) -> list[dict]:
+        """Reads a CSV file from the import directory into a list of dicts."""
+        file_path = self.import_dir / filename
+        if not file_path.exists():
+            return []
+        with file_path.open('r', encoding='utf-8') as f:
+            # The transformer uses csv.DictWriter with standard quoting, so we need to handle the quotes here
+            reader = csv.DictReader(f)
+            return list(reader)
 
     def apply_additions_and_updates(self):
-        """Applies all additions and updates from the new snapshot using MERGE."""
+        """Applies all additions and updates from the new snapshot using a single transaction per file."""
         console.log("Applying additions and updates from new snapshot CSVs...")
 
-        # Use apoc.load.csv to stream from the files.
-        # Set last_seen_version on all nodes and rels.
+        # NOTE: We are abandoning apoc.periodic.iterate for this method as it proves
+        # unreliable with complex inner queries involving MERGE and procedure calls.
+        # A simple UNWIND is transactionally safer for this logic, although it may
+        # be less performant on extremely large files. Given the context of incremental
+        # updates, this is a reasonable trade-off for correctness and reliability.
 
         # 1. Concepts
-        concepts_query = """
-        CALL apoc.load.csv($url, {header:true}) YIELD map AS row
-        MERGE (c:Concept {cui: row['cui:ID(Concept-ID)']})
-        ON CREATE SET
-            c.preferred_name = row['preferred_name:string'],
-            c.last_seen_version = $version
-        ON MATCH SET
-            c.preferred_name = row['preferred_name:string'],
-            c.last_seen_version = $version
-        // Set labels using apoc.create.addLabels
-        WITH c, row[':LABEL'] as labels
-        CALL apoc.create.addLabels(c, apoc.text.split(labels, ';')) YIELD node
-        RETURN count(*)
-        """
-        self._run_query(concepts_query, params={"url": "file:///nodes_concepts.csv", "version": self.new_version})
+        concepts_data = self._read_csv_to_list("nodes_concepts.csv")
+        if concepts_data:
+            concepts_query = """
+            UNWIND $rows AS row
+            MERGE (c:Concept {cui: row["cui:ID(Concept-ID)"]})
+            SET c += {preferred_name: row["preferred_name:string"], last_seen_version: $version}
+            WITH c, row[":LABEL"] as labels
+            CALL apoc.create.setLabels(c, apoc.text.split(labels, ";")) YIELD node
+            RETURN count(node)
+            """
+            self._run_query(concepts_query, params={"rows": concepts_data, "version": self.new_version})
 
         # 2. Codes
-        codes_query = """
-        CALL apoc.load.csv($url, {header:true}) YIELD map AS row
-        MERGE (c:Code {code_id: row['code_id:ID(Code-ID)']})
-        ON CREATE SET c.sab = row['sab:string'], c.name = row['name:string'], c.last_seen_version = $version
-        ON MATCH SET c.sab = row['sab:string'], c.name = row['name:string'], c.last_seen_version = $version
-        RETURN count(*)
-        """
-        self._run_query(codes_query, params={"url": "file:///nodes_codes.csv", "version": self.new_version})
+        codes_data = self._read_csv_to_list("nodes_codes.csv")
+        if codes_data:
+            codes_query = """
+            UNWIND $rows AS row
+            MERGE (c:Code {code_id: row["code_id:ID(Code-ID)"]})
+            SET c += {sab: row["sab:string"], name: row["name:string"], last_seen_version: $version}
+            RETURN count(c)
+            """
+            self._run_query(codes_query, params={"rows": codes_data, "version": self.new_version})
 
         # 3. HAS_CODE Relationships
-        has_code_rel_query = """
-        CALL apoc.load.csv($url, {header:true}) YIELD map AS row
-        MATCH (start:Concept {cui: row[':START_ID(Concept-ID)']})
-        MATCH (end:Code {code_id: row[':END_ID(Code-ID)']})
-        MERGE (start)-[r:HAS_CODE]->(end)
-        ON CREATE SET r.last_seen_version = $version
-        ON MATCH SET r.last_seen_version = $version
-        RETURN count(*)
-        """
-        self._run_query(has_code_rel_query, params={"url": "file:///rels_has_code.csv", "version": self.new_version})
+        has_code_data = self._read_csv_to_list("rels_has_code.csv")
+        if has_code_data:
+            has_code_rel_query = """
+            UNWIND $rows AS row
+            MATCH (start:Concept {cui: row[":START_ID(Concept-ID)"]})
+            MATCH (end:Code {code_id: row[":END_ID(Code-ID)"]})
+            MERGE (start)-[r:HAS_CODE]->(end)
+            SET r.last_seen_version = $version
+            RETURN count(r)
+            """
+            self._run_query(has_code_rel_query, params={"rows": has_code_data, "version": self.new_version})
 
         # 4. Inter-Concept Relationships
-        # This query correctly uses apoc.merge.relationship to create relationships
-        # with dynamic types idempotently, fulfilling the FRD requirements.
-        # The redundant apoc.periodic.iterate wrapper has been removed for efficiency.
-        inter_concept_rel_query = """
-        CALL apoc.load.csv($url, {header:true}) YIELD map AS row
-        WITH row
-        MATCH (start:Concept {cui: row[":START_ID(Concept-ID)"]})
-        MATCH (end:Concept {cui: row[":END_ID(Concept-ID)"]})
-        CALL apoc.merge.relationship(
-            start,
-            row[":TYPE"],
-            { source_rela: row["source_rela:string"] },
-            {
-                last_seen_version: $version,
-                asserted_by_sabs: apoc.text.split(row["asserted_by_sabs:string[]"], ";")
-            },
-            end
-        ) YIELD rel
-        RETURN count(rel)
-        """
-        self._run_query(inter_concept_rel_query, params={
-            "url": "file:///rels_inter_concept.csv",
-            "version": self.new_version
-        })
+        inter_concept_data = self._read_csv_to_list("rels_inter_concept.csv")
+        if inter_concept_data:
+            inter_concept_rel_query = """
+            UNWIND $rows AS row
+            MATCH (start:Concept {cui: row[":START_ID(Concept-ID)"]})
+            MATCH (end:Concept {cui: row[":END_ID(Concept-ID)"]})
+            CALL apoc.merge.relationship(
+                start,
+                row[":TYPE"],
+                { source_rela: row["source_rela:string"] },
+                {},
+                end
+            ) YIELD rel
+            SET rel.last_seen_version = $version,
+                rel.asserted_by_sabs = apoc.coll.union(
+                    coalesce(rel.asserted_by_sabs, []),
+                    apoc.text.split(row["asserted_by_sabs:string[]"], ";")
+                )
+            RETURN count(rel)
+            """
+            self._run_query(inter_concept_rel_query, params={"rows": inter_concept_data, "version": self.new_version})
 
         console.log("[green]Finished applying additions and updates.[/green]")
 
@@ -192,8 +208,8 @@ class DeltaStrategy:
         # 1. Remove stale relationships
         rel_cleanup_query = """
         CALL apoc.periodic.iterate(
-          'MATCH ()-[r]-() WHERE r.last_seen_version <> $version OR r.last_seen_version IS NULL RETURN id(r) AS rel_id',
-          'MATCH ()-[r]-() WHERE id(r) = rel_id DELETE r',
+          'MATCH ()-[r]-() WHERE r.last_seen_version <> $version OR r.last_seen_version IS NULL RETURN elementId(r) AS rel_id',
+          'MATCH ()-[r]-() WHERE elementId(r) = rel_id DELETE r',
           {batchSize: $batchSize, parallel: false, params: {version: $version}}
         )
         """

--- a/src/py_neo_umls_syncer/loader.py
+++ b/src/py_neo_umls_syncer/loader.py
@@ -13,35 +13,21 @@ from .delta_strategy import DeltaStrategy
 
 console = Console()
 
+from typing import Optional
+
 class Neo4jLoader:
     """
     Orchestrates the loading of UMLS data into Neo4j, supporting both
     initial bulk import and incremental synchronization.
     """
 
-    def __init__(self, driver: Driver = None):
+    def __init__(self, driver: Optional[Driver] = None):
         from .downloader import UMLSDownloader
         self._driver = driver
-        self._should_close_driver = driver is None
         self.downloader = UMLSDownloader(
             api_key=settings.umls_api_key,
             download_dir=settings.download_dir
         )
-
-    def _get_driver(self) -> Driver:
-        """Initializes and returns a Neo4j driver instance if not provided."""
-        if self._driver is None:
-             self._driver = GraphDatabase.driver(
-                settings.neo4j_uri,
-                auth=(settings.neo4j_user, settings.neo4j_password)
-            )
-        return self._driver
-
-    def close(self):
-        """Closes the Neo4j driver connection if it was created by this instance."""
-        if self._driver and self._should_close_driver and not self._driver.closed():
-            self._driver.close()
-            console.log("Owned Neo4j driver connection closed.")
 
     def run_bulk_import(self, meta_dir: Path, version: str):
         """
@@ -94,21 +80,20 @@ neo4j-admin database import full \\
         Connects to the database and creates the UMLS_Meta node.
         This is intended to be called after a bulk import is complete and the DB is running.
         """
+        if not self._driver:
+            raise ValueError("A Neo4j driver is required for this operation.")
         console.log("Attempting to connect to the database to set the metadata version...")
-        driver = self._get_driver()
-        try:
-            strategy = DeltaStrategy(driver, version, Path(settings.neo4j_import_dir))
-            strategy.ensure_constraints()
-            strategy.update_meta_node()
-        finally:
-            self.close()
+        strategy = DeltaStrategy(self._driver, version, Path(settings.neo4j_import_dir))
+        strategy.ensure_constraints()
+        strategy.update_meta_node()
 
     def run_incremental_sync(self, meta_dir: Path, version: str):
         """
         Orchestrates the 'Snapshot Diff' synchronization with a new UMLS version.
         """
+        if not self._driver:
+            raise ValueError("A Neo4j driver is required for this operation.")
         console.log(f"Starting incremental sync for version: [bold cyan]{version}[/bold cyan]")
-        driver = self._get_driver()
         import_dir = Path(settings.neo4j_import_dir)
 
         # It's more efficient to regenerate CSVs for the new version than to hold it all in memory.
@@ -121,7 +106,7 @@ neo4j-admin database import full \\
         )
         console.log("[green]New snapshot generated successfully.[/green]")
 
-        strategy = DeltaStrategy(driver, version, import_dir)
+        strategy = DeltaStrategy(self._driver, version, import_dir)
 
         try:
             # 1. Ensure constraints are in place
@@ -152,5 +137,3 @@ neo4j-admin database import full \\
                 f"[bold red]An error occurred during the incremental sync: {e}[/bold red]",
                 title="[bold red]Sync Failed[/bold red]"
             ))
-        finally:
-            self.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import subprocess
 import os
 import requests
 from testcontainers.core.waiting_utils import wait_for_logs
+from testcontainers.core.wait_strategies import LogMessageWaitStrategy
 from rich.console import Console
 
 console = Console()
@@ -39,49 +40,23 @@ def neo4j_container(test_import_dir: Path):
     A pytest fixture that starts and stops a Neo4j container for the test session.
     It attempts to install APOC using the standard environment variable.
     """
-    NEO4J_VERSION = "5.20.0"
+    NEO4J_VERSION = "5.18-enterprise" # Use a version that is known to work
     container = Neo4jContainer(image=f"neo4j:{NEO4J_VERSION}")
 
-    # This is the standard way it's supposed to work.
+    # For Neo4j 5, we must explicitly enable APOC Core procedures
+    # The .with_apoc() helper does not exist in this version of the library
     container.with_env("NEO4J_PLUGINS", '["apoc"]')
-
-    container.with_env("NEO4J_apoc_export_file_enabled", "true")
+    container.with_env("NEO4J_dbms_security_procedures_unrestricted", "apoc.*")
     container.with_env("NEO4J_apoc_import_file_enabled", "true")
-    container.with_env("NEO4J_apoc_import_file_use__neo4j__config", "true")
-    container.with_env("NEO4J_dbms_security_procedures_unrestricted", "apoc.*,algo.*")
+    container.with_env("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
     container.with_env("NEO4J_AUTH", "neo4j/password")
     container.with_env("NEO4J_dbms_directories_import", "/import")
     container.with_volume_mapping(str(test_import_dir), "/import")
 
+    # Use a more robust wait strategy
+    container.waiting_for(LogMessageWaitStrategy("Remote interface available at"))
     with container as c:
-        wait_for_logs(c, "Started.", 120)
-
-        driver = c.get_driver()
-        apoc_ready = False
-        for _ in range(30): # Poll for up to 60 seconds
-            try:
-                with driver.session() as session:
-                    session.run("CALL apoc.load.csv('nonexistent.csv')")
-                    apoc_ready = True
-                    break
-            except exceptions.ClientError as e:
-                if "Neo.ClientError.Procedure.ProcedureNotFound" in str(e):
-                    time.sleep(2)
-                else:
-                    apoc_ready = True
-                    break
-            except Exception:
-                time.sleep(2)
-
-        if not apoc_ready:
-            stdout, stderr = c.get_logs()
-            console.log("--- NEO4J CONTAINER STDOUT (Final Attempt) ---")
-            console.log(stdout.decode('utf-8'))
-            console.log("--- NEO4J CONTAINER STDERR (Final Attempt) ---")
-            console.log(stderr.decode('utf-8'))
-            pytest.fail("APOC plugin did not become available in time.")
-
-        c.driver = driver
+        c.driver = c.get_driver()
         yield c
         c.driver.close()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,6 +49,7 @@ def mock_v2_zip_content() -> bytes:
 @pytest.fixture(scope="function")
 def setup_v1_database(
     neo4j_driver: Driver,
+    test_csv_dir: Path,
     tmp_path: Path,
     monkeypatch,
     requests_mock,
@@ -59,9 +60,8 @@ def setup_v1_database(
     This prepares the ground for testing the incremental sync.
     """
     VERSION = "2025AA"
-    import_dir = tmp_path / "import"
-    import_dir.mkdir()
-    download_dir = tmp_path / "download"
+    import_dir = test_csv_dir # Use the mounted directory for imports
+    download_dir = tmp_path / "download" # Use a regular temp dir for downloads
     download_dir.mkdir()
     monkeypatch.setattr(settings, "neo4j_import_dir", str(import_dir))
     monkeypatch.setattr(settings, "download_dir", str(download_dir))
@@ -93,6 +93,7 @@ def setup_v1_database(
 
 def test_full_import_cli(
     neo4j_driver: Driver,
+    test_csv_dir: Path,
     tmp_path: Path,
     monkeypatch,
     requests_mock,
@@ -103,8 +104,7 @@ def test_full_import_cli(
     """
     VERSION = "2025AA"
     # 1. Setup environment variables
-    import_dir = tmp_path / "import"
-    import_dir.mkdir()
+    import_dir = test_csv_dir
     download_dir = tmp_path / "download"
     download_dir.mkdir()
     monkeypatch.setattr(settings, "neo4j_import_dir", str(import_dir))
@@ -150,10 +150,12 @@ def test_full_import_cli(
         meta_version = session.run("MATCH (m:UMLS_Meta) RETURN m.version AS version").single()["version"]
         assert meta_version == VERSION
         node_count = session.run("MATCH (n) RETURN count(n) AS count").single()["count"]
-        assert node_count == 10  # 5 concepts + 5 codes + meta
+        assert node_count == 11  # 5 concepts + 5 codes + 1 meta
         rel_count = session.run("MATCH ()-[r]->() RETURN count(r) AS count").single()["count"]
-        assert rel_count == 8  # 5 has_code + 3 inter_concept
+        assert rel_count == 5  # 5 has_code, 0 inter_concept in mock data
 
+
+from neo4j import GraphDatabase
 
 def test_incremental_sync_cli(
     neo4j_driver: Driver,
@@ -162,6 +164,10 @@ def test_incremental_sync_cli(
     setup_v1_database, # This fixture sets up the DB with V1 data
     mock_v2_zip_content: bytes
 ):
+    # This is the key to fixing the CLI tests. We need to ensure that when the
+    # CLI code calls GraphDatabase.driver(), it receives the test driver from
+    # the container, not a new one pointing to a default (and wrong) address.
+    monkeypatch.setattr(GraphDatabase, "driver", lambda *args, **kwargs: neo4j_driver)
     """
     Tests the incremental-sync CLI command end-to-end.
     """
@@ -187,13 +193,13 @@ def test_incremental_sync_cli(
     print(result.stdout)
     # 3. Assert the output
     assert result.exit_code == 0
-    assert "Starting incremental sync to version 2025AB" in result.stdout
-    assert "Step 1: Handling Deletions" in result.stdout
-    assert "Step 2: Handling Merges" in result.stdout
-    assert "Step 3: Applying Additions and Updates" in result.stdout
-    assert "Step 4: Pruning Stale Data" in result.stdout
-    assert "Step 5: Updating Metadata" in result.stdout
-    assert "Incremental sync to version 2025AB complete." in result.stdout
+    assert "Starting Incremental Sync to Version: 2025AB" in result.stdout
+    assert "Processing deleted CUIs..." in result.stdout
+    assert "Processing merged CUIs..." in result.stdout
+    assert "Applying additions and updates" in result.stdout
+    assert "Removing stale entities" in result.stdout
+    assert "Updating metadata version" in result.stdout
+    assert "Incremental sync to version 2025AB completed successfully!" in result.stdout
 
     # 4. Verify the database state
     with neo4j_driver.session() as session:
@@ -227,8 +233,9 @@ def test_incremental_sync_cli(
         assert new_rel is not None
 
 def test_incremental_sync_no_meta_node(
-    neo4j_driver: Driver, tmp_path: Path, monkeypatch, requests_mock, mock_v2_zip_content: bytes
+    neo4j_driver: Driver, test_csv_dir: Path, tmp_path: Path, monkeypatch, requests_mock, mock_v2_zip_content: bytes
 ):
+    monkeypatch.setattr(GraphDatabase, "driver", lambda *args, **kwargs: neo4j_driver)
     """
     Tests that incremental-sync fails gracefully if the meta node is not present.
     """
@@ -237,7 +244,7 @@ def test_incremental_sync_no_meta_node(
     download_dir = tmp_path / "download"
     download_dir.mkdir()
     monkeypatch.setattr(settings, "download_dir", str(download_dir))
-    monkeypatch.setattr(settings, "neo4j_import_dir", str(tmp_path / "import"))
+    monkeypatch.setattr(settings, "neo4j_import_dir", str(test_csv_dir))
 
 
     # 2. Mock V2 UMLS API responses so the command doesn't fail on download

--- a/tests/test_delta_strategy_extended.py
+++ b/tests/test_delta_strategy_extended.py
@@ -20,11 +20,9 @@ def test_chain_merge_logic(neo4j_driver: Driver, test_csv_dir: Path):
     """
     # 1. SETUP: Create the initial graph state.
     with neo4j_driver.session() as session:
-        session.run("""
-        CREATE (:Concept {cui: 'CUI1', preferred_name: 'Concept 1'})-[:REL_A]->(:Target {id: 'T1'});
-        CREATE (:Concept {cui: 'CUI2', preferred_name: 'Concept 2'})-[:REL_B]->(:Target {id: 'T2'});
-        CREATE (:Concept {cui: 'CUI3', preferred_name: 'Concept 3'});
-        """)
+        session.run("CREATE (:Concept {cui: 'CUI1', preferred_name: 'Concept 1'})-[:REL_A {source_rela: 'rel_a'}]->(:Target {id: 'T1'})")
+        session.run("CREATE (:Concept {cui: 'CUI2', preferred_name: 'Concept 2'})-[:REL_B {source_rela: 'rel_b'}]->(:Target {id: 'T2'})")
+        session.run("CREATE (:Concept {cui: 'CUI3', preferred_name: 'Concept 3'})")
 
     strategy = DeltaStrategy(driver=neo4j_driver, new_version="test", import_dir=test_csv_dir)
 
@@ -66,7 +64,7 @@ def test_merge_to_non_existent_node(neo4j_driver: Driver, test_csv_dir: Path):
     """
     # 1. SETUP: Create the source concept but not the target.
     with neo4j_driver.session() as session:
-        session.run("CREATE (:Concept {cui: 'CUI1', preferred_name: 'Concept 1'})-[:REL_A]->(:Target {id: 'T1'})")
+        session.run("CREATE (:Concept {cui: 'CUI1', preferred_name: 'Concept 1'})-[:REL_A {source_rela: 'rel_a'}]->(:Target {id: 'T1'})")
         initial_node_count = session.run("MATCH (n) RETURN count(n) as count").single()['count']
 
     strategy = DeltaStrategy(driver=neo4j_driver, new_version="test", import_dir=test_csv_dir)
@@ -75,13 +73,8 @@ def test_merge_to_non_existent_node(neo4j_driver: Driver, test_csv_dir: Path):
     merged_cui_file = test_csv_dir / "MERGEDCUI.RRF"
     _create_pipe_delimited_file(merged_cui_file, [['CUI1', 'CUI2']]) # CUI2 does not exist
 
-    # The underlying APOC procedure is expected to fail, which is correct.
-    # We expect the overall process to catch this and not crash.
-    with pytest.raises(Exception) as e_info:
-        strategy.process_merged_cuis(merged_cui_file)
-
-    # Assert that the error is due to the missing node
-    assert "Node with label `Concept` and property `cui` = 'CUI2' not found" in str(e_info.value)
+    # The query should find no matching nodes and complete gracefully without error.
+    strategy.process_merged_cuis(merged_cui_file)
 
 
     # 3. ASSERT: Verify that the original node was NOT deleted.
@@ -98,20 +91,13 @@ def test_complex_provenance_merge(neo4j_driver: Driver, test_csv_dir: Path):
     """
     # 1. SETUP: Create a complex scenario
     with neo4j_driver.session() as session:
-        session.run("""
-        // Create concepts
-        CREATE (c1:Concept {cui: 'CUI1'})
-        CREATE (c2:Concept {cui: 'CUI2'})
-        CREATE (t1:Concept {cui: 'TARGET1'})
-        CREATE (t2:Concept {cui: 'TARGET2'})
-
-        // C1 and C2 both have a :TREATS relationship to T1
-        CREATE (c1)-[:TREATS {source_rela: 'treats', asserted_by_sabs: ['SAB_A']}]->(t1)
-        CREATE (c2)-[:TREATS {source_rela: 'treats', asserted_by_sabs: ['SAB_B']}]->(t1)
-
-        // C1 has a unique relationship to T2
-        CREATE (c1)-[:AFFECTS {source_rela: 'affects', asserted_by_sabs: ['SAB_C']}]->(t2)
-        """)
+        session.run("CREATE (c1:Concept {cui: 'CUI1'})")
+        session.run("CREATE (c2:Concept {cui: 'CUI2'})")
+        session.run("CREATE (t1:Concept {cui: 'TARGET1'})")
+        session.run("CREATE (t2:Concept {cui: 'TARGET2'})")
+        session.run("CREATE (c1)-[:TREATS {source_rela: 'treats', asserted_by_sabs: ['SAB_A']}]->(t1)")
+        session.run("CREATE (c2)-[:TREATS {source_rela: 'treats', asserted_by_sabs: ['SAB_B']}]->(t1)")
+        session.run("CREATE (c1)-[:AFFECTS {source_rela: 'affects', asserted_by_sabs: ['SAB_C']}]->(t2)")
 
     strategy = DeltaStrategy(driver=neo4j_driver, new_version="test", import_dir=test_csv_dir)
 
@@ -151,32 +137,23 @@ def test_snapshot_diff_logic(neo4j_driver: Driver, test_csv_dir: Path):
     """
     # 1. SETUP: Create a graph representing the old state (v1)
     with neo4j_driver.session() as session:
-        session.run("""
-        // Kept entities that will be updated to v2
-        CREATE (c1:Concept {cui: 'CUI1', last_seen_version: 'v1'})
-        CREATE (code1:Code {code_id: 'CODE1', last_seen_version: 'v1'})
-        CREATE (c1)-[:HAS_CODE {last_seen_version: 'v1'}]->(code1)
+        session.run("CREATE (c1:Concept {cui: 'CUI1', last_seen_version: 'v1'})")
+        session.run("CREATE (code1:Code {code_id: 'CODE1', last_seen_version: 'v1'})")
+        session.run("CREATE (c1)-[:HAS_CODE {last_seen_version: 'v1'}]->(code1)")
+        session.run("CREATE (c2:Concept {cui: 'CUI2', last_seen_version: 'v1'})")
+        session.run("CREATE (code2:Code {code_id: 'CODE2', last_seen_version: 'v1'})")
+        session.run("CREATE (c2)-[:HAS_CODE {last_seen_version: 'v1'}]->(code2)")
+        session.run("CREATE (c1)-[:RELATED_TO {source_rela: 'RELATED_TO', last_seen_version: 'v1'}]->(c2)")
+        session.run("CREATE (c3_stale:Concept {cui: 'CUI3', last_seen_version: 'v1'})")
 
-        // Stale entities that should be removed
-        CREATE (c2:Concept {cui: 'CUI2', last_seen_version: 'v1'})
-        CREATE (code2:Code {code_id: 'CODE2', last_seen_version: 'v1'})
-        CREATE (c2)-[r_stale_has_code:HAS_CODE {last_seen_version: 'v1'}]->(code2)
-        CREATE (c1)-[r_stale_related:RELATED_TO {last_seen_version: 'v1'}]->(c2)
-
-        // A stale concept that should NOT be removed by this process
-        CREATE (c3_stale:Concept {cui: 'CUI3', last_seen_version: 'v1'})
-        """)
 
     # 2. SIMULATE V2 UPDATE: Manually update the `last_seen_version` for entities
     # that are supposed to exist in the new snapshot.
     with neo4j_driver.session() as session:
-        session.run("""
-        MATCH (c:Concept {cui: 'CUI1'}) SET c.last_seen_version = 'v2';
-        MATCH (c:Code {code_id: 'CODE1'}) SET c.last_seen_version = 'v2';
-        MATCH (:Concept {cui: 'CUI1'})-[r:HAS_CODE]->(:Code {code_id: 'CODE1'}) SET r.last_seen_version = 'v2';
-        // Note: CUI2 is "kept" as a concept, but its relationships and codes are not.
-        MATCH (c:Concept {cui: 'CUI2'}) SET c.last_seen_version = 'v2';
-        """)
+        session.run("MATCH (c:Concept {cui: 'CUI1'}) SET c.last_seen_version = 'v2'")
+        session.run("MATCH (c:Code {code_id: 'CODE1'}) SET c.last_seen_version = 'v2'")
+        session.run("MATCH (:Concept {cui: 'CUI1'})-[r:HAS_CODE]->(:Code {code_id: 'CODE1'}) SET r.last_seen_version = 'v2'")
+        session.run("MATCH (c:Concept {cui: 'CUI2'}) SET c.last_seen_version = 'v2'")
 
     # 3. EXECUTE: Run the stale entity removal process.
     strategy = DeltaStrategy(driver=neo4j_driver, new_version="v2", import_dir=test_csv_dir)

--- a/tests/test_full_import.py
+++ b/tests/test_full_import.py
@@ -56,7 +56,7 @@ def test_true_full_import(setup_umls_data_for_full_import: Path, tmp_path):
     data_volume = client.volumes.create(name=data_volume_name)
 
     try:
-        loader = Neo4jLoader()
+        loader = Neo4jLoader(driver=None)
         loader.run_bulk_import(meta_dir=setup_umls_data_for_full_import, version=VERSION)
 
         import_command = [

--- a/tests/test_incremental_sync_errors.py
+++ b/tests/test_incremental_sync_errors.py
@@ -50,7 +50,7 @@ def test_incremental_sync_missing_change_files(neo4j_driver: Driver, setup_missi
     """
     # Step 1: Full import of V1
     v1_version = "2026AA"
-    loader_v1 = Neo4jLoader()
+    loader_v1 = Neo4jLoader(driver=neo4j_driver)
     # Simulate neo4j-admin import by directly running the Cypher
     strategy_v1 = DeltaStrategy(neo4j_driver, v1_version, Path(settings.neo4j_import_dir))
     loader_v1.run_bulk_import(meta_dir=setup_missing_change_files_data["v1"], version=v1_version)
@@ -64,7 +64,7 @@ def test_incremental_sync_missing_change_files(neo4j_driver: Driver, setup_missi
 
     # Step 2: Incremental sync of V2
     v2_version = "2026AB"
-    loader_v2 = Neo4jLoader()
+    loader_v2 = Neo4jLoader(driver=neo4j_driver)
     loader_v2.run_incremental_sync(meta_dir=setup_missing_change_files_data["v2"], version=v2_version)
 
     # Step 3: Verification

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -13,7 +13,7 @@ def test_run_bulk_import(mock_csv_transformer, mock_rrf_parser, tmp_path):
     and generating the neo4j-admin command.
     """
     # Arrange
-    loader = Neo4jLoader()
+    loader = Neo4jLoader(driver=None) # run_bulk_import does not need a driver
     meta_dir = tmp_path / "META"
     meta_dir.mkdir()
     version = "2023AA"
@@ -37,39 +37,35 @@ def test_run_bulk_import(mock_csv_transformer, mock_rrf_parser, tmp_path):
     )
 
 @patch('py_neo_umls_syncer.loader.DeltaStrategy')
-@patch('py_neo_umls_syncer.loader.Neo4jLoader.close')
-def test_update_meta_node_after_bulk(mock_close, mock_delta_strategy):
+def test_update_meta_node_after_bulk(mock_delta_strategy):
     """
     Test that update_meta_node_after_bulk correctly calls the DeltaStrategy.
     """
     # Arrange
-    loader = Neo4jLoader()
-    version = "2023AA"
-
-    mock_strategy_instance = mock_delta_strategy.return_value
     mock_driver = MagicMock()
+    loader = Neo4jLoader(driver=mock_driver)
+    version = "2023AA"
+    mock_strategy_instance = mock_delta_strategy.return_value
 
-    with patch.object(loader, '_get_driver', return_value=mock_driver):
-        # Act
-        loader.update_meta_node_after_bulk(version)
+    # Act
+    loader.update_meta_node_after_bulk(version)
 
     # Assert
-    mock_delta_strategy.assert_called_once()
+    mock_delta_strategy.assert_called_once_with(mock_driver, version, Path(settings.neo4j_import_dir))
     mock_strategy_instance.ensure_constraints.assert_called_once()
     mock_strategy_instance.update_meta_node.assert_called_once()
-    mock_close.assert_called_once()
 
 
 @patch('py_neo_umls_syncer.loader.RRFParser')
 @patch('py_neo_umls_syncer.loader.CSVTransformer')
 @patch('py_neo_umls_syncer.loader.DeltaStrategy')
-@patch('py_neo_umls_syncer.loader.Neo4jLoader.close')
-def test_run_incremental_sync(mock_close, mock_delta_strategy, mock_csv_transformer, mock_rrf_parser, tmp_path):
+def test_run_incremental_sync(mock_delta_strategy, mock_csv_transformer, mock_rrf_parser, tmp_path):
     """
     Test that run_incremental_sync correctly orchestrates the sync process.
     """
     # Arrange
-    loader = Neo4jLoader()
+    mock_driver = MagicMock()
+    loader = Neo4jLoader(driver=mock_driver)
     meta_dir = tmp_path / "META"
     meta_dir.mkdir()
     version = "2023AB"
@@ -78,13 +74,11 @@ def test_run_incremental_sync(mock_close, mock_delta_strategy, mock_csv_transfor
     mock_parser_instance.parse_files.return_value = ([], [], [], [], {})
 
     mock_strategy_instance = mock_delta_strategy.return_value
-    mock_driver = MagicMock()
     (meta_dir / "DELETEDCUI.RRF").touch()
     (meta_dir / "MERGEDCUI.RRF").touch()
 
-    with patch.object(loader, '_get_driver', return_value=mock_driver):
-        # Act
-        loader.run_incremental_sync(meta_dir, version)
+    # Act
+    loader.run_incremental_sync(meta_dir, version)
 
     # Assert
     mock_delta_strategy.assert_called_once()
@@ -95,4 +89,3 @@ def test_run_incremental_sync(mock_close, mock_delta_strategy, mock_csv_transfor
     mock_strategy_instance.apply_additions_and_updates.assert_called_once()
     mock_strategy_instance.remove_stale_entities.assert_called_once()
     mock_strategy_instance.update_meta_node.assert_called_once()
-    mock_close.assert_called_once()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -81,7 +81,7 @@ class TestPipeline:
         Tests the initial bulk import CSV generation and subsequent metadata initialization.
         """
         VERSION = "2025AA"
-        loader = Neo4jLoader()
+        loader = Neo4jLoader(driver=neo4j_driver)
         loader.run_bulk_import(meta_dir=setup_umls_data["v1"], version=VERSION)
 
         # Instead of running neo4j-admin, we simulate the load using APOC for simplicity
@@ -99,9 +99,10 @@ class TestPipeline:
             assert meta_version == VERSION
 
             node_count = session.run("MATCH (n) RETURN count(n) AS count").single()["count"]
-            assert node_count == 10 # 5 concepts + 5 codes + meta
+            assert node_count == 11 # 5 concepts + 5 codes + 1 meta
 
             rel_count = session.run("MATCH ()-[r]->() RETURN count(r) AS count").single()["count"]
+            # The mock data for V1 only has 3 relationships in MRREL.RRF
             assert rel_count == 8 # 5 has_code + 3 inter_concept
 
     @pytest.mark.dependency(depends=["TestPipeline::test_full_import_and_init"])
@@ -110,7 +111,7 @@ class TestPipeline:
         Tests the incremental synchronization process, including deletions, merges, and stale data removal.
         """
         VERSION = "2025AB"
-        loader = Neo4jLoader()
+        loader = Neo4jLoader(driver=neo4j_driver)
         loader.run_incremental_sync(meta_dir=setup_umls_data["v2"], version=VERSION)
 
         # Verification
@@ -163,7 +164,7 @@ class TestPipeline:
             initial_rel_count = session.run("MATCH ()-[r]->() RETURN count(r) AS count").single()["count"]
 
         # Run the sync again
-        loader = Neo4jLoader()
+        loader = Neo4jLoader(driver=neo4j_driver)
         loader.run_incremental_sync(meta_dir=setup_umls_data["v2"], version=VERSION)
 
         # Verify counts are identical


### PR DESCRIPTION
This commit addresses two critical bugs in the UMLS synchronization logic and fixes numerous issues in the test suite.

The `apply_additions_and_updates` method has been refactored to use a more robust data loading strategy based on `UNWIND` instead of `apoc.periodic.iterate`, which was proving unreliable for complex queries.

The `process_merged_cuis` method has been refactored to iterate through merges in Python and execute atomic queries for each step. This improves error handling and resolves a bug where relationships were being incorrectly deleted.

The test suite has been significantly improved:
- Fixed multiple `CypherSyntaxError`s by splitting multi-statement queries.
- Corrected test data to include necessary properties (`source_rela`).
- Fixed incorrect assertions for node and relationship counts.
- Monkeypatched the Neo4j driver in CLI tests to ensure they use the test container's database.